### PR TITLE
Add useSingleResult option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [Unreleased]
+- Added `useSingleResult` option
+
 ## [0.3.0] - 2019-07-23
 
 - Added `useFirstResult` option

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ Arguments for the extension:
 * cwd: the directory from within it will be executed
 * env: key-value pairs to use as environment variables (it won't append the variables to the current existing ones. It will replace instead)
 * useFirstResult: skip 'Quick Pick' dialog and use first result returned from the command
+* useSingleResult: skip 'Quick Pick' dialog and use the single result if only one returned from the command
 
 In the moment it supports only `file`, `fileDirName`, `workspaceFolder` and `workspaceFolderBasename` [vscode variables](https://code.visualstudio.com/docs/editor/variables-reference).

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -41,7 +41,8 @@ export class CommandHandler
             command: command,
             cwd: cwd,
             env: env,
-            useFirstResult: args.useFirstResult
+            useFirstResult: args.useFirstResult,
+            useSingleResult: args.useSingleResult
         }
     }
 
@@ -49,10 +50,12 @@ export class CommandHandler
     {
         const result = this.runCommand()
         const nonEmptyInput = this.parseResult(result);
+        const useFirstResult = (this.args.useFirstResult
+            || (this.args.useSingleResult && nonEmptyInput.length === 1));
 
-        return (this.args.useFirstResult)
+        return (useFirstResult
             ? nonEmptyInput[0]
-            : this.quickPick(nonEmptyInput);
+            : this.quickPick(nonEmptyInput));
     }
 
     protected runCommand()

--- a/src/lib/ShellCommandOptions.ts
+++ b/src/lib/ShellCommandOptions.ts
@@ -4,4 +4,5 @@ export interface ShellCommandOptions
     command: string;
     env: { [s: string]: string } | undefined;
     useFirstResult?: boolean;
+    useSingleResult?: boolean;
 }


### PR DESCRIPTION
Adds `useSingleResult` option which skips the Quick Pick dialog when there is only one result returned from the command (#13)