### PR TITLE
Added support for ${config:variable_name} and ${env:variable_name}

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,7 @@ Arguments for the extension:
 * fieldSeparator: the string that separates `value`, `label`, `description` and `detail` fields
 * description: shown as a placeholder in 'Quick Pick', provides context for the input
 
-*Variables in arguments*
 As of today, the extension supports variable substitution for: 
-
 * a subset of predefined variables like `file`, `fileDirName`, `workspaceFolder` and `workspaceFolderBasename`, pattern: `${variable}` 
 * all config variables, pattern: `${config:variable}`
 * all environment variables, pattern: `${env:variable}`

--- a/README.md
+++ b/README.md
@@ -90,4 +90,11 @@ Arguments for the extension:
 * fieldSeparator: the string that separates `value`, `label`, `description` and `detail` fields
 * description: shown as a placeholder in 'Quick Pick', provides context for the input
 
-In the moment it supports only `file`, `fileDirName`, `workspaceFolder` and `workspaceFolderBasename` [vscode variables](https://code.visualstudio.com/docs/editor/variables-reference).
+*Variables in arguments*
+As of today, the extension supports variable substitution for: 
+
+* a subset of predefined variables like `file`, `fileDirName`, `workspaceFolder` and `workspaceFolderBasename`, pattern: `${variable}` 
+* all config variables, pattern: `${config:variable}`
+* all environment variables, pattern: `${env:variable}`
+
+For a complete vscode variables documentation please refer to [vscode variables](https://code.visualstudio.com/docs/editor/variables-reference).


### PR DESCRIPTION
Hi,

first of all: many thanks for a great extension - it saved my day!

Since I am working with multi folder workspace I needed a way to tell my script invoked via your extension where is the root folder of my workspace. I used to have it defined in workspace configuration in "settings" section. 
In the task definition such value can be accessed via pattern ${config:variable}, where "variable" is the name of the setting. I decided to try adding such support in your extension, and it turned out to be trivial.

Basically all placeholders of ${config:variable} pattern will be replaced with value taken from workspace configuration "settings" section.
For example, given a following workspace configuration:

```
{
	"settings": {
		"something": "beautiful"
	}
}
```

and inputs defined like:

```
  "inputs": [
    {
      "id": "input",
      "type": "command",
      "command": "shellCommand.execute",
      "args": {
          "command": "echo ${config:something}"
      }
    }
  ]
```
the variable "inputTest" will get "beautiful" value.

Since it was so easy I also added support for environment variables using similar pattern ${env:variable}.

Please be aware that it is my first ever code in ts and vscode extension, so feel free to modify it as you deem fit.

Thanks,
Roman
p.s.
I believe there should be some generic way to replace all occurences of supported variable placeholders provided by vscode framework.
