### PR TITLE
opt(VariableResolver): support read settings from folder level settings.xml

### DIFF
--- a/src/lib/VariableResolver.ts
+++ b/src/lib/VariableResolver.ts
@@ -78,14 +78,28 @@ export class VariableResolver
     }
 
     protected bindWorkspaceConfigVariable(value: string): string {
-        let result = this.configVarRegex.exec(value);
-        if (!result)
-        {
+        let matchResult = this.configVarRegex.exec(value);
+        if (!matchResult) {
             return '';
         }
-
         // Get value from workspace configuration "settings" dictionary
-        return vscode.workspace.getConfiguration().get(result[1], '');
+        let workspaceResult = vscode.workspace.getConfiguration().get(matchResult[1], '');
+        if (workspaceResult) {
+            return workspaceResult;
+        }
+
+        let activeFolderResult = vscode.workspace.getConfiguration("", vscode.window.activeTextEditor?.document.uri).get(matchResult[1], '');
+        if (activeFolderResult) {
+            return activeFolderResult;
+        }
+
+        for (const w of vscode.workspace.workspaceFolders!) {
+            let currentFolderResult = vscode.workspace.getConfiguration("", w.uri).get(matchResult![1], '');
+            if (currentFolderResult) {
+                return currentFolderResult;
+            }
+        }
+        return "";
     }
 
     protected bindEnvVariable(value: string): string {


### PR DESCRIPTION
For issue [config in folder level not substituted in commad](https://github.com/augustocdias/vscode-shell-command/issues/27) #27 
Now command could use variable from folder's internal .vscode/settings.json