### PR TITLE
Added asynchronouse resolving of ${command:...} variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.6.0] - 2021-10-21
+- Added support for ${command:...} variable substitutions
+
 ## [1.5.0] - 2021-07-08
 - Added basic variable dependency resolution
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ As of today, the extension supports variable substitution for:
 * all config variables, pattern: `${config:variable}`
 * all environment variables, pattern: `${env:variable}`
 * input variables which have been defined with shellCommand.execute, pattern: `${input:variable}` (limited supported see below for usage)
+* Support for ${command:...} pattern, for example to extract CMake's build directory using `${command:cmake.buildDirectory}`.
 
 For a complete vscode variables documentation please refer to [vscode variables](https://code.visualstudio.com/docs/editor/variables-reference).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "tasks-shell-input",
 	"displayName": "Tasks Shell Input",
 	"description": "Use shell commands as input for your tasks",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"publisher": "augustocdias",
 	"repository": {
 		"url": "https://github.com/augustocdias/vscode-shell-command"

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -24,30 +24,11 @@ export class CommandHandler
         }
         this.inputId = this.resolveCommandToInputId(args.command);
         this.userInputContext = userInputContext;
-
-        const resolver = new VariableResolver();
-        const resolve = (arg: string, userInputContext?: UserInputContext) => resolver.resolve(arg, userInputContext);
-
-        const command = resolve(args.command, userInputContext);
-        if (command === undefined) {
-            throw new ShellCommandException('Your command is badly formatted and variables could not be resolved');
-        }
-
-        const env = args.env;
-        if (env !== undefined) {
-            for (const key in env!) {
-                if (env!.hasOwnProperty(key)) {
-                    env![key] = resolve(env![key]) || '';
-                }
-            }
-        }
-
-        const cwd = (args.cwd) ? resolve(args.cwd!) : vscode.workspace.workspaceFolders![0].uri.fsPath;
-
+        
         this.args = {
-            command: command,
-            cwd: cwd,
-            env: env,
+            command: args.command,
+            cwd: args.cwd,
+            env: args.env,
             useFirstResult: args.useFirstResult,
             useSingleResult: args.useSingleResult,
             fieldSeparator: args.fieldSeparator,
@@ -59,8 +40,33 @@ export class CommandHandler
         }
     }
 
-    handle()
+    protected async resolveArgs()
     {
+        const resolver = new VariableResolver();
+
+        const command = await resolver.resolve(this.args.command, this.userInputContext);
+        if (command === undefined) {
+            throw new ShellCommandException('Your command is badly formatted and variables could not be resolved');
+        }
+        else {
+            this.args.command = command;
+        }
+
+        if (this.args.env !== undefined) {
+            for (const key in this.args.env!) {
+                if (this.args.env!.hasOwnProperty(key)) {
+                    this.args.env![key] = await resolver.resolve(this.args.env![key]) || '';
+                }
+            }
+        }
+
+        this.args.cwd = this.args.cwd ? await resolver.resolve(this.args.cwd!) : vscode.workspace.workspaceFolders![0].uri.fsPath;
+    }
+    
+    async handle()
+    {
+       await this.resolveArgs();
+
         const result = this.runCommand();
         const nonEmptyInput = this.parseResult(result);
         const useFirstResult = (this.args.useFirstResult


### PR DESCRIPTION
Support for ${command:...} variable substitutions so that variables from other extensions like the CMake Tools extension can be passed to this extension as arguments. For example ${command:cmake.buildDirectory}.

Refer to https://github.com/augustocdias/vscode-shell-command/issues/29
