### PR TITLE
support multi root workspaces for input variables

### DIFF
--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -124,14 +124,18 @@ export class CommandHandler
         if (!cmd)
             return undefined;
 
-        const launchInputs = vscode.workspace.getConfiguration().get('launch.inputs') || [];
-        const taskInputs = vscode.workspace.getConfiguration().get('tasks.inputs') || [];
-
         let inputs: any[] = [];
-        if (Array.isArray(launchInputs))
-            inputs = inputs.concat(launchInputs);
-        if (Array.isArray(taskInputs))
-            inputs = inputs.concat(taskInputs);
+        if (vscode.workspace.workspaceFolders) {
+            vscode.workspace.workspaceFolders?.forEach(function (folder) {
+                const launchInputs = vscode.workspace.getConfiguration("launch", folder.uri).get('inputs') || [];
+                const taskInputs = vscode.workspace.getConfiguration('tasks', folder.uri).get('inputs') || [];
+                if (Array.isArray(launchInputs))
+                    inputs = inputs.concat(launchInputs);
+                if (Array.isArray(taskInputs))
+                    inputs = inputs.concat(taskInputs);
+            });
+        }
+
         return inputs.filter(input => input && input.args && input.args.command && input.args.command == cmd)[0]?.id;
  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "es6",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"ES2021",
+			"DOM"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
The extension variables did not work for multi-root workspaces.

Its my first try to commit to a vscode extension. I'm not sure if everything is correct, but my particular problem seems to be fixed with this commit.