### PR TITLE
fix: `userInputContext` auto reset invalid

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,8 @@ export function activate(this: any, context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand(command, callback, this));
 
     // Triggers a reset of the userInput context
-    context.subscriptions.push(vscode.tasks.onDidStartTask(userInputContext.reset));
-    context.subscriptions.push(vscode.debug.onDidStartDebugSession(userInputContext.reset));
+    context.subscriptions.push(vscode.tasks.onDidStartTask(() => userInputContext.reset()));
+    context.subscriptions.push(vscode.debug.onDidStartDebugSession(() => userInputContext.reset()));
 
 }
 


### PR DESCRIPTION
I'm using some ${input:XXX} to communicate between `launch.json` and `task.json`.
https://github.com/augustocdias/vscode-shell-command/blob/c16e81822e54f5482487347d373945797b73ffb1/src/extension.ts#L27-L28
https://github.com/augustocdias/vscode-shell-command/blob/c16e81822e54f5482487347d373945797b73ffb1/src/lib/UserInputContext.ts#L8-L11
make `this` detached and reset invalid, so that my command can't work properly.
![image](https://user-images.githubusercontent.com/52597061/185766355-249f09b5-4e95-4e54-9eff-a65688919745.png)
