### PR TITLE
Remember previous value and default it next time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.8.0] - 2023-02-15
+
+- Added `rememberPrevious` option and force user to set the taskId if using rememberPrevious
+
 ## [1.7.5] - 2022-11-10
 
 - Fix userInputContext auto reset invalid

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Arguments for the extension:
 * env: key-value pairs to use as environment variables (it won't append the variables to the current existing ones. It will replace instead)
 * useFirstResult: skip 'Quick Pick' dialog and use first result returned from the command
 * useSingleResult: skip 'Quick Pick' dialog and use the single result if only one returned from the command
+* rememberPrevious: remember the value you previously selected and default to it the next time (default false) (:warning: **need taskID to be set**)
+* taskId: Unique id to use for storing the last-used value.
 * fieldSeparator: the string that separates `value`, `label`, `description` and `detail` fields
 * description: shown as a placeholder in 'Quick Pick', provides context for the input
 * maxBuffer: largest amount of data in bytes allowed on stdout. Default is 1024 * 1024. If exceeded ENOBUFS error will be displayed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Tasks Shell Input",
     "description": "Use shell commands as input for your tasks",
     "icon": "icon.png",
-    "version": "1.7.5",
+    "version": "1.8.0",
     "publisher": "augustocdias",
     "repository": {
         "url": "https://github.com/augustocdias/vscode-shell-command"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(this: any, context: vscode.ExtensionContext) {
     const userInputContext = new UserInputContext();
     const callback = (args: ShellCommandOptions) => {
         try {
-            const handler = new CommandHandler(args, userInputContext);
+            const handler = new CommandHandler(args, userInputContext, context);
             return handler.handle();
         } catch (error) {
             const message = (error instanceof ShellCommandException)

--- a/src/lib/QuickPickItem.ts
+++ b/src/lib/QuickPickItem.ts
@@ -1,0 +1,6 @@
+export interface QuickPickItem {
+        value: string;
+        label: string;
+        description?: string;
+        detail?: string;
+}

--- a/src/lib/ShellCommandOptions.ts
+++ b/src/lib/ShellCommandOptions.ts
@@ -5,6 +5,7 @@ export interface ShellCommandOptions
     env: { [s: string]: string } | undefined;
     useFirstResult?: boolean;
     useSingleResult?: boolean;
+    rememberPrevious?: boolean;
     fieldSeparator?: string;
     description?: string;
     maxBuffer?: number;


### PR DESCRIPTION
Hello,

Very nice extension, thank you.

As we were needed this functionality, I took a little bit of my time to implement it.
It answers #35 .

Basically, I have added a new argument called "rememberPrevious". If set to true, the selected value will be saved and reused the next time (if found in the next output of the command). It defaults to false so it won't change the behavior of previously setup tasks.
You'll also need to set "taskId" so we can link the saved value to the current task.

I tried as much as possible not to change too many things in your code.
Unfortunately, the use of `window.showQuickPick()` does not allow us to specify the default and active item so I had to switch to `window.createQuickPick()`, hence the more verbose `quickPick()` function. 

I based my code on : [showQuickPickDefault() from memento](https://github.com/joelspadin/vscode-memento-inputs/blob/0e1f4237286ebd1ab6da16fec7edf3544c15837d/src/extension.ts#L72)

I took the liberty to update the readme, changelog and package version to 1.8.0 as it's not a fix but a new feature.

No breaking change I believe.

Hope you can merge that !