### PR TITLE
Add an option to error out when the command returns empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Arguments for the extension:
 * `env`: key-value pairs to use as environment variables (it won't append the variables to the current existing ones. It will replace instead)
 * `useFirstResult`: skip 'Quick Pick' dialog and use first result returned from the command
 * `useSingleResult`: skip 'Quick Pick' dialog and use the single result if only one returned from the command
+* `disallowEmptyResult`: disallow the returned value from the command to be empty
 * `rememberPrevious`: remember the value you previously selected and default to it the next time (default false) (:warning: **need taskId to be set**)
 * `taskId`: Unique id to use for storing the last-used value.
 * `fieldSeparator`: the string that separates `value`, `label`, `description` and `detail` fields

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -131,6 +131,9 @@ export class CommandHandler {
     }
 
     protected parseResult(result: string): QuickPickItem[] {
+        if (this.args.disallowEmptyResult && result.trim().length == 0) {
+            throw new ShellCommandException(`The command for input '${this.input.id}' returned empty result.`);
+        }
         return result
             .split(this.EOL)
             .map<QuickPickItem>((value: string) => {

--- a/src/lib/ShellCommandOptions.ts
+++ b/src/lib/ShellCommandOptions.ts
@@ -6,6 +6,7 @@ export interface ShellCommandOptions
     env?: { [s: string]: string };
     useFirstResult?: boolean;
     useSingleResult?: boolean;
+    disallowEmptyResult?: boolean;
     rememberPrevious?: boolean;
     fieldSeparator?: string;
     description?: string;


### PR DESCRIPTION
Before the fix, if empty result is retuned, the error message is 
```
Cannot read properties of undefined (reading 'value')
```

With the fix, the UI can pop up better message for debugging. 
```
The command for input 'test' returned empty result.
```



