### PR TITLE
parse boolean type user inputs in case they're passed in as strings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as subprocess from 'child_process';
-import { ShellCommandOptions } from './lib/ShellCommandOptions';
 import { CommandHandler } from './lib/CommandHandler';
 import { UserInputContext } from './lib/UserInputContext';
 import { ShellCommandException } from './util/exceptions';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { ShellCommandException } from './util/exceptions';
 export function activate(this: any, context: vscode.ExtensionContext) {
     const command = 'shellCommand.execute';
     const userInputContext = new UserInputContext();
-    const callback = (args: ShellCommandOptions) => {
+    const callback = (args: object) => {
         try {
             const handler = new CommandHandler(args, userInputContext, context, subprocess);
             return handler.handle();

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -16,49 +16,50 @@ export class CommandHandler {
     protected commandArgs: string[] | undefined;
     protected subprocess: typeof child_process;
 
-    constructor(args: ShellCommandOptions,
+    constructor(args: object,
                 userInputContext: UserInputContext,
                 context: vscode.ExtensionContext,
                 subprocess: typeof child_process,
     ) {
-        if (!Object.prototype.hasOwnProperty.call(args, "command")) {
+        this.args = this.resolveBooleanArgs(args);
+        if (!Object.prototype.hasOwnProperty.call(this.args, "command")) {
             throw new ShellCommandException('Please specify the "command" property.');
         }
 
-        const command = CommandHandler.resolveCommand(args.command);
+        const command = CommandHandler.resolveCommand(this.args.command);
 
         if (typeof command !== "string") {
             throw new ShellCommandException(
                 'The "command" property should be a string or an array of ' +
-                `string but got "${typeof args.command}".`
+                `string but got "${typeof command}".`
             );
         }
 
-        if (!(args.commandArgs === undefined || Array.isArray(args.commandArgs))) {
+        if (!(this.args.commandArgs === undefined || Array.isArray(this.args.commandArgs))) {
             throw new ShellCommandException(
                 'The "commandArgs" property should be an array of strings ' +
-                `(if defined) but got "${typeof args.commandArgs}".`
+                `(if defined) but got "${typeof this.args.commandArgs}".`
             );
         }
 
         this.command = command;
-        this.commandArgs = args.commandArgs as string[] | undefined;
+        this.commandArgs = this.args.commandArgs as string[] | undefined;
 
-        this.input = this.resolveTaskToInput(args.taskId);
+        this.input = this.resolveTaskToInput(this.args.taskId);
 
         this.userInputContext = userInputContext;
-        this.args = this.resolveBooleanArgs(args);
         this.context = context;
         this.subprocess = subprocess;
     }
 
-    protected resolveBooleanArgs(args: ShellCommandOptions): ShellCommandOptions {
+    protected resolveBooleanArgs(args: object): ShellCommandOptions {
+        const opt = args as ShellCommandOptions;
         const resolvedBooleans = {
-            useFirstResult: this.parseBoolean(args.useFirstResult, false),
-            useSingleResult: this.parseBoolean(args.useSingleResult, false),
-            rememberPrevious: this.parseBoolean(args.rememberPrevious, false),
+            useFirstResult: this.parseBoolean(opt.useFirstResult, false),
+            useSingleResult: this.parseBoolean(opt.useSingleResult, false),
+            rememberPrevious: this.parseBoolean(opt.rememberPrevious, false),
         };
-        return {...args, ...resolvedBooleans};
+        return {...args, ...resolvedBooleans} as ShellCommandOptions;
     }
 
     protected parseBoolean(value: unknown, defaultValue: boolean): boolean {
@@ -75,7 +76,7 @@ export class CommandHandler {
                 return false;
             }
         }
-        vscode.window.showWarningMessage(`Can not parse the boolean value: ${value}, use the default: ${defaultValue}`);
+        vscode.window.showWarningMessage(`Cannot parse the boolean value: ${value}, use the default: ${defaultValue}`);
         return defaultValue;
     }
 

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -61,7 +61,7 @@ export class CommandHandler {
         return {...args, ...resolvedBooleans};
     }
 
-    protected parseBoolean(value: boolean | undefined, defaultValue: boolean): boolean {
+    protected parseBoolean(value: unknown, defaultValue: boolean): boolean {
         if (value === undefined) {
             return defaultValue;
         }
@@ -69,8 +69,13 @@ export class CommandHandler {
             return value;
         }
         if (typeof value === 'string') {
-            return value === defaultValue.toString() ? defaultValue : !defaultValue;
+            if (value.toLowerCase() === 'true') {
+                return true;
+            } else if (value.toLowerCase() === 'false') {
+                return false;
+            }
         }
+        vscode.window.showWarningMessage(`Can not parse the boolean value: ${value}, use the default: ${defaultValue}`);
         return defaultValue;
     }
 

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -47,9 +47,31 @@ export class CommandHandler {
         this.input = this.resolveTaskToInput(args.taskId);
 
         this.userInputContext = userInputContext;
-        this.args = args;
+        this.args = this.resolveBooleanArgs(args);
         this.context = context;
         this.subprocess = subprocess;
+    }
+
+    protected resolveBooleanArgs(args: ShellCommandOptions): ShellCommandOptions {
+        const resolvedBooleans = {
+            useFirstResult: this.parseBoolean(args.useFirstResult, false),
+            useSingleResult: this.parseBoolean(args.useSingleResult, false),
+            rememberPrevious: this.parseBoolean(args.rememberPrevious, false),
+        };
+        return {...args, ...resolvedBooleans};
+    }
+
+    protected parseBoolean(value: boolean | undefined, defaultValue: boolean): boolean {
+        if (value === undefined) {
+            return defaultValue;
+        }
+        if (typeof value === 'boolean') {
+            return value;
+        }
+        if (typeof value === 'string') {
+            return value === defaultValue.toString() ? defaultValue : !defaultValue;
+        }
+        return defaultValue;
     }
 
     protected async resolveArgs() {


### PR DESCRIPTION
While working on https://github.com/augustocdias/vscode-shell-command/pull/96 , I found there is a general issue regarding how a user provided boolean arg is used. The current code assumes those variable are boolean (or undefined), but in fact user can provide them as a string in which the variable is always treated as "true" (e.g `"useFirstResult": "false"`)
This seems confusing and error prone, so add this parsing before we use them.  
 