### PR TITLE
Implement allowCustomValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+
+- Add support for custom values
+
 ## [1.11.0] 2024-09-21
 
 - Add support for getting results from stderr (fix issue #86)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Arguments for the extension:
 * `useFirstResult`: skip 'Quick Pick' dialog and use first result returned from the command
 * `useSingleResult`: skip 'Quick Pick' dialog and use the single result if only one returned from the command
 * `rememberPrevious`: remember the value you previously selected and default to it the next time (default false) (:warning: **need taskId to be set**)
+* `allowCustomValues`: If true, it's possible to enter a new value that is not part of the command output.
 * `taskId`: Unique id to use for storing the last-used value.
 * `fieldSeparator`: the string that separates `value`, `label`, `description` and `detail` fields
 * `description`: shown as a placeholder in 'Quick Pick', provides context for the input

--- a/src/lib/CommandHandler.test.ts
+++ b/src/lib/CommandHandler.test.ts
@@ -275,6 +275,7 @@ describe("Argument parsing", () => {
     test("Test defaults and that all boolean properties use parseBoolean", () => {
         expect(CommandHandler.resolveArgs({ extraTestThing: 42 }))
             .toStrictEqual({
+                allowCustomValues: false,
                 rememberPrevious: false,
                 useFirstResult: false,
                 useSingleResult: false,

--- a/src/lib/ShellCommandOptions.ts
+++ b/src/lib/ShellCommandOptions.ts
@@ -7,6 +7,7 @@ export interface ShellCommandOptions
     useFirstResult?: boolean;
     useSingleResult?: boolean;
     rememberPrevious?: boolean;
+    allowCustomValues?: boolean;
     fieldSeparator?: string;
     description?: string;
     maxBuffer?: number;


### PR DESCRIPTION
Thanks to [Abrahamsen3](https://github.com/Abrahamsen3) for getting it started in #45.

Add the `allowCustomValues` to allow entering arbitrary values.

Unfortunately, this VSCode picker stuff is very hard to test, especially with the current test infrastructure.