### PR TITLE
Clean up CommandHandler quickPick resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Add support for custom values
+- Add support for custom values (#33)
+- Fix bug in pick selection (#95)
 
 ## [1.11.0] 2024-09-21
 


### PR DESCRIPTION
Possibly fix #95

It seems like in #57 changed from `showQuickPick` to `createQuickPick`. The `userInputContext.recordInput` logic was added to `onDidHide`, but not `onDidAccept`, which seems like a bug to me.