### PR TITLE
Autofix: Default value is not recorded for useFirstResult / useSingleResult 

### DIFF
--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -146,16 +146,22 @@ export class CommandHandler {
     async handle() {
         await this.resolveArgs();
 
+        const recordInput = (value: string) => {
+            if (this.input.id && this.userInputContext) {
+                this.userInputContext.recordInput(this.input.id, value);
+            }
+            if (this.args.rememberPrevious && this.args.taskId) {
+                this.setDefault(this.args.taskId, [value]);
+            }
+        };
         const result = await this.runCommand();
         const nonEmptyInput = this.parseResult(result);
         const useFirstResult =
             this.args.useFirstResult ||
             (this.args.useSingleResult && nonEmptyInput.length === 1);
 
-        if (useFirstResult) {
-            if (this.input.id && this.userInputContext) {
-                this.userInputContext.recordInput(this.input.id, nonEmptyInput[0].value);
-            }
+            recordInput(nonEmptyInput[0].value);
+            return nonEmptyInput[0].value;
             return nonEmptyInput[0].value;
         } else {
             const selectedItems = await this.quickPick(nonEmptyInput);
@@ -166,11 +172,8 @@ export class CommandHandler {
             }
 
             const result = selectedItems.join(this.args.multiselectSeparator!);
-            this.userInputContext.recordInput(this.input.id, result);
-
-            if (this.args.rememberPrevious && this.args.taskId) {
-                this.setDefault(this.args.taskId, selectedItems);
-            }
+            recordInput(result);
+            return result;
 
             return result;
         }


### PR DESCRIPTION
This change addresses the issue where the default value is not recorded for useFirstResult and useSingleResult cases. We modify the handle() method in the CommandHandler class to record the input value before returning it in these cases. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    