### PR TITLE
Refactor UserInputContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased] 2024-XX-XX
+
+- Fix default value not recorded for useFirstResult / useSingleResult (#117)
+- Add support for ${taskId:} input variables
+- Do not reset user input context (#95)
+
 ## [1.12.4] 2024-10-03
 
 - Work around VSCode bug with activeItems and selectedItems (#112)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ As of today, the extension supports variable substitution for:
 * the remembered value (the default value when `rememberPrevious` is true), available as `${rememberedValue}`
 * all config variables, pattern: `${config:variable}`
 * all environment variables (`tasks.json` `options.env` with fallback to parent process), pattern: `${env:variable}`
-* input variables which have been defined with `shellCommand.execute`, pattern: `${input:variable}` (limited supported see below for usage)
+* input variables that have been defined with `shellCommand.execute`, pattern: `${input:variable}` (uses `input.id`) and `${taskId:task}` (uses `input.args.taskId`) (limited supported see below for usage)
 * Support for ${command:...} pattern, for example to extract CMake's build directory using `${command:cmake.buildDirectory}`.
 * multi-folder workspace support: `${workspaceFolder}` (the folder whose `.vscode/tasks.json` defined the given task), `${workspaceFolder[1]}` (a specific folder by index), and `${workspaceFolder:name}` (a specific folder by name)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,4 @@ export function activate(this: any, context: vscode.ExtensionContext) {
     };
 
     context.subscriptions.push(vscode.commands.registerCommand(command, callback, this));
-
-    // Triggers a reset of the userInput context
-    context.subscriptions.push(vscode.tasks.onDidStartTask(() => userInputContext.reset()));
-    context.subscriptions.push(vscode.debug.onDidStartDebugSession(() => userInputContext.reset()));
 }

--- a/src/lib/UserInputContext.ts
+++ b/src/lib/UserInputContext.ts
@@ -1,19 +1,25 @@
 export class UserInputContext
 {
-    protected recordedInputs: { [id: string] : string; } = {};
+    protected recordedInputsByInputId: { [id: string] : string | undefined; } = {};
+    protected recordedInputsByTaskId: { [id: string] : string | undefined; } = {};
 
-    reset(): void
-    {
-        this.recordedInputs = {};
+    recordInputByInputId(inputId: string | undefined, taskValue: string | undefined): void {
+        if (inputId !== undefined) {
+            this.recordedInputsByInputId[inputId] = taskValue;
+        }
     }
 
-    recordInput(inputId: string, taskValue: string): void
-    {
-        this.recordedInputs[inputId] = taskValue;
+    recordInputByTaskId(taskId: string | undefined, taskValue: string | undefined): void {
+        if (taskId !== undefined) {
+            this.recordedInputsByTaskId[taskId] = taskValue;
+        }
     }
 
-    lookupInputValue(inputId: string): string
-    {
-        return this.recordedInputs[inputId];
+    lookupInputValueByInputId(inputId: string): string | undefined {
+        return this.recordedInputsByInputId[inputId];
+    }
+
+    lookupInputValueByTaskId(taskId: string): string | undefined {
+        return this.recordedInputsByTaskId[taskId];
     }
 }


### PR DESCRIPTION
- Fix default value not recorded for useFirstResult / useSingleResult (#117)
- Add support for ${taskId:} input variables
- Do not reset user input context (#95)
    - I don't see why it's needed and I think it's leading to bugs
