### PR TITLE
completeInput: do not search for a task/launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ VSCode renders it like this:
 * `maxBuffer`: largest amount of data in bytes allowed on stdout. Default is 1024 * 1024. If exceeded ENOBUFS error will be displayed
 * `defaultOptions`: if the command doesn't return anything, the list provided will be set for the user to choose from
 * `stdio`: specifies whether to get the results from `stdout`, `stderr`, or `both`. Default is `stdout`.
+* `completeInput`: If true this `args` argument is complete. We do not search the workspaces for an input with this `command`. Useful if command called from another extension. Default is `false`.
 
 As of today, the extension supports variable substitution for:
 

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -59,7 +59,7 @@ export class CommandHandler {
         this.command = command;
         this.commandArgs = this.args.commandArgs as string[] | undefined;
 
-        this.input = this.resolveTaskToInput(this.args.taskId);
+        this.input = args.completeInput ? {args} : this.resolveTaskToInput(this.args.taskId);
 
         this.userInputContext = userInputContext;
         this.context = context;
@@ -125,6 +125,7 @@ export class CommandHandler {
 
         this.args.cwd = this.args.cwd
             ? await resolver.resolve(this.args.cwd ?? '')
+            : this.input.args.completeInput ? undefined
             : vscode.workspace.workspaceFolders?.[this.input.workspaceIndex].uri.fsPath;
     }
 

--- a/src/lib/VariableResolver.ts
+++ b/src/lib/VariableResolver.ts
@@ -13,6 +13,7 @@ export type Input = {
         commandArgs: string[] | undefined;
         cwd: string;
         env: Record<string, string>;
+        completeInput: boolean | undefined;
     },
     id: string;
     type: string;


### PR DESCRIPTION
If the command `shellCommand.execute` is called from an extension there is no `input` to be found.

Based on an extra argument: `completeInput`, there is no search for an `input`.

This solves #131