### PR TITLE
Extracted the taskId criteria while searching the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.18.3] 2025-05-28
+
+- Extracted the `taskId` criteria while searching the input. (#131)
+
 ## [1.18.2] 2025-05-15
 
 - Fix task arguments handling to prevent incorrect values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tasks-shell-input",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tasks-shell-input",
-      "version": "1.18.2",
+      "version": "1.18.3",
       "devDependencies": {
         "@types/glob": "8.1.0",
         "@types/node": "20.11.30",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tasks Shell Input",
   "description": "Use shell commands as input for your tasks",
   "icon": "icon.png",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "publisher": "augustocdias",
   "repository": {
     "url": "https://github.com/augustocdias/vscode-shell-command"

--- a/src/lib/CommandHandler.ts
+++ b/src/lib/CommandHandler.ts
@@ -479,8 +479,12 @@ export class CommandHandler {
                 duplicateTaskIds.add(input.args.taskId);
             }
 
-            if (input.args.command === this.command &&
-                input?.args?.taskId === taskId &&
+            if (taskId) {
+                if (input?.args?.taskId === taskId) {
+                    result = input;
+                }
+            }
+            else if (input.args.command === this.command &&
                 CommandHandler.compareCommandArgs(this.commandArgs,
                                                   input?.args?.commandArgs)) {
                   result = input;


### PR DESCRIPTION
The very presence of an "Id" in the name suggests that this entity must be something unique. But, previously the "taskId" was used among of the command and its arguments while searching the input object in the resolveTaskToInput() function. Among of other effects, this was leading to exception throwing for the use-case like described in the ticket (combined usage of the Shell Command and CommandVariable extensions usage). This patch if doesn't fix #131, then gives a workaround for it. Specifying the "taskId" for the Shell Command calls lets the variables substitution with CommandVariable extension (using the `variableSubstArgs` argument).